### PR TITLE
Filter Action Items

### DIFF
--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -144,6 +144,7 @@ def stats():
         .join(Proposal.arbiter) \
         .filter(Proposal.status == ProposalStatus.LIVE) \
         .filter(ProposalArbiter.status == ProposalArbiterStatus.MISSING) \
+        .filter(Proposal.stage != ProposalStage.CANCELED) \
         .scalar()
     proposal_milestone_payouts_count = db.session.query(func.count(Proposal.id)) \
         .join(Proposal.milestones) \


### PR DESCRIPTION
Currently, proposals that are cancelled will continue to admin action to assign arbiters.

This PR adds a filter to prevent Admins from being prompted to set arbiters on proposals that have been cancelled.

