### PR TITLE
Admin proposal stage not canceled filter

### DIFF
--- a/admin/src/components/Home/index.tsx
+++ b/admin/src/components/Home/index.tsx
@@ -32,7 +32,7 @@ class Home extends React.Component {
         <div>
           <Icon type="exclamation-circle" /> There are <b>{proposalNoArbiterCount}</b>{' '}
           live proposals <b>without an arbiter</b>.{' '}
-          <Link to="/proposals?filters[]=STATUS_LIVE&filters[]=ARBITER_MISSING">
+          <Link to="/proposals?filters[]=STATUS_LIVE&filters[]=ARBITER_MISSING&filters[]=STAGE_NOT_CANCELED">
             Click here
           </Link>{' '}
           to view them.
@@ -42,14 +42,16 @@ class Home extends React.Component {
         <div>
           <Icon type="exclamation-circle" /> There are{' '}
           <b>{proposalMilestonePayoutsCount}</b> proposals <b>with approved payouts</b>.{' '}
-          <Link to="/proposals?filters[]=MILESTONE_ACCEPTED">Click here</Link> to view
-          them.
+          <Link to="/proposals?filters[]=MILESTONE_ACCEPTED&filters[]=STAGE_NOT_CANCELED">
+            Click here
+          </Link>{' '}
+          to view them.
         </div>
       ),
       !!contributionRefundableCount && (
         <div>
-          <Icon type="exclamation-circle" /> There are <b>{contributionRefundableCount}</b>{' '}
-          contributions <b>ready to be refunded</b>.{' '}
+          <Icon type="exclamation-circle" /> There are{' '}
+          <b>{contributionRefundableCount}</b> contributions <b>ready to be refunded</b>.{' '}
           <Link to="/contributions?filters[]=REFUNDABLE">Click here</Link> to view them.
         </div>
       ),

--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -64,18 +64,18 @@ class ProposalDetailNaked extends React.Component<Props, State> {
       return m.datePaid ? prev - parseFloat(m.payoutPercent) : prev;
     }, 100);
 
-    const renderDeleteControl = () => (
-      <Popconfirm
-        onConfirm={this.handleDelete}
-        title="Delete proposal?"
-        okText="delete"
-        cancelText="cancel"
-      >
-        <Button icon="delete" className="ProposalDetail-controls-control" block>
-          Delete
-        </Button>
-      </Popconfirm>
-    );
+    // const renderDeleteControl = () => (
+    //   <Popconfirm
+    //     onConfirm={this.handleDelete}
+    //     title="Delete proposal?"
+    //     okText="delete"
+    //     cancelText="cancel"
+    //   >
+    //     <Button icon="delete" className="ProposalDetail-controls-control" block>
+    //       Delete
+    //     </Button>
+    //   </Popconfirm>
+    // );
 
     const renderCancelControl = () => {
       const disabled = this.getCancelAndRefundDisabled();
@@ -507,10 +507,10 @@ class ProposalDetailNaked extends React.Component<Props, State> {
     store.fetchProposalDetail(this.getIdFromQuery());
   };
 
-  private handleDelete = () => {
-    if (!store.proposalDetail) return;
-    store.deleteProposal(store.proposalDetail.proposalId);
-  };
+  // private handleDelete = () => {
+  //   if (!store.proposalDetail) return;
+  //   store.deleteProposal(store.proposalDetail.proposalId);
+  // };
 
   private handleCancelCancel = () => {
     this.setState({ showCancelAndRefundPopover: false });

--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -64,19 +64,6 @@ class ProposalDetailNaked extends React.Component<Props, State> {
       return m.datePaid ? prev - parseFloat(m.payoutPercent) : prev;
     }, 100);
 
-    // const renderDeleteControl = () => (
-    //   <Popconfirm
-    //     onConfirm={this.handleDelete}
-    //     title="Delete proposal?"
-    //     okText="delete"
-    //     cancelText="cancel"
-    //   >
-    //     <Button icon="delete" className="ProposalDetail-controls-control" block>
-    //       Delete
-    //     </Button>
-    //   </Popconfirm>
-    // );
-
     const renderCancelControl = () => {
       const disabled = this.getCancelAndRefundDisabled();
 
@@ -411,7 +398,6 @@ class ProposalDetailNaked extends React.Component<Props, State> {
           <Col span={6}>
             {/* ACTIONS */}
             <Card size="small" className="ProposalDetail-controls">
-              {/* {renderDeleteControl()} */}
               {renderCancelControl()}
               {renderArbiterControl()}
               {renderBountyControl()}
@@ -506,11 +492,6 @@ class ProposalDetailNaked extends React.Component<Props, State> {
   private loadDetail = () => {
     store.fetchProposalDetail(this.getIdFromQuery());
   };
-
-  // private handleDelete = () => {
-  //   if (!store.proposalDetail) return;
-  //   store.deleteProposal(store.proposalDetail.proposalId);
-  // };
 
   private handleCancelCancel = () => {
     this.setState({ showCancelAndRefundPopover: false });

--- a/admin/src/components/ProposalDetail/index.tsx
+++ b/admin/src/components/ProposalDetail/index.tsx
@@ -411,7 +411,7 @@ class ProposalDetailNaked extends React.Component<Props, State> {
           <Col span={6}>
             {/* ACTIONS */}
             <Card size="small" className="ProposalDetail-controls">
-              {renderDeleteControl()}
+              {/* {renderDeleteControl()} */}
               {renderCancelControl()}
               {renderArbiterControl()}
               {renderBountyControl()}

--- a/admin/src/types.ts
+++ b/admin/src/types.ts
@@ -87,6 +87,7 @@ export enum PROPOSAL_STAGE {
   COMPLETED = 'COMPLETED',
   FAILED = 'FAILED',
   CANCELED = 'CANCELED',
+  NOT_CANCELED = 'NOT_CANCELED',
 }
 export interface Proposal {
   proposalId: number;

--- a/admin/src/util/statuses.ts
+++ b/admin/src/util/statuses.ts
@@ -12,6 +12,7 @@ export interface StatusSoT<E> {
   tagDisplay: string;
   tagColor: string;
   hint: string;
+  not?: boolean;
 }
 
 export const MILESTONE_STAGES: Array<StatusSoT<MILESTONE_STAGE>> = [
@@ -130,6 +131,13 @@ export const PROPOSAL_STAGES: Array<StatusSoT<PROPOSAL_STAGE>> = [
     tagColor: '#eb4118',
     hint:
       'Proposal was canceled by an admin and is currently refunding all contributors.',
+  },
+  {
+    id: PROPOSAL_STAGE.NOT_CANCELED,
+    tagDisplay: 'NOT Canceled',
+    tagColor: '#eb4118',
+    hint: 'Proposal has NOT been canceled.',
+    not: true,
   },
 ];
 

--- a/admin/webpack.config.js
+++ b/admin/webpack.config.js
@@ -18,7 +18,7 @@ module.exports = {
     publicPath: '/',
     chunkFilename: isDev ? '[name].chunk.js' : '[name].[chunkhash:8].chunk.js',
   },
-  devtool: 'inline-source-map',
+  devtool: isDev ? 'inline-source-map' : 'source-map',
   devServer: {
     port: 3500,
     contentBase: './build',

--- a/backend/grant/admin/views.py
+++ b/backend/grant/admin/views.py
@@ -149,6 +149,7 @@ def stats():
     proposal_milestone_payouts_count = db.session.query(func.count(Proposal.id)) \
         .join(Proposal.milestones) \
         .filter(Proposal.status == ProposalStatus.LIVE) \
+        .filter(Proposal.stage != ProposalStage.CANCELED) \
         .filter(Milestone.stage == MilestoneStage.ACCEPTED) \
         .scalar()
     # Count contributions on proposals that didn't get funded for users who have specified a refund address


### PR DESCRIPTION
Originally I thought we could set status=DELETED when a Proposal is canceled. However, we still want users to be able to view their canceled proposals via direct link (as mentioned in #253).

That being the case, it made sense to implement the STAGE_NOT_CANCELED filter for the admin proposals list.

## What this does
- backend: `paginate.py` support "not" filter for `STAGE_NOT_CANCELED`
- backend: add the filter to admin stats end-point for milestone payouts count
- admin: add the filter to the Home links for "without arbiter" & "with approved payouts"
- admin: add support to the Proposals list for the new filter
- admin: remove the "delete" button from ProposalDetail as it is not supported at present
- **extra** admin: separate the sourcemaps from the bundle to reduce the size on prod builds (webpack)

## Steps to test 

### canceled proposal
- create, stake, approve, publish & fully fund a proposal
- admin: Home - check that the proposal shows up in the count for "without an arbiter" and "with approved payouts"
    - check that the proposal shows up in each respective action item link
- admin: ProposalDetail - click the "Cancel & refund" button to cancel
- admin: Home - check that the proposal is not included in the count for "without an arbiter" and "with approved payouts"
    - check that the proposal no longer shows in each respective action item link
- admin: ProposalDetail - check that the "Delete" button is no longer visible in the right column
- frontend: check that the proposal no longer shows in the list, but direct linking still works (add id to the URL)

### webpack build sourcemaps
- `zcash-grant-system/admin> yarn build` (should build)
- `zcash-grant-system/admin> yarn start` (should serve)
- check that `/build` has`*.js.map` and `*.css.map`

