### PR TITLE
Default to "ALL" in stage filter

### DIFF
--- a/frontend/client/modules/proposals/reducers.ts
+++ b/frontend/client/modules/proposals/reducers.ts
@@ -9,7 +9,7 @@ import {
   LoadableProposalPage,
   Moreable,
 } from 'types';
-import { PROPOSAL_SORT, PROPOSAL_STAGE } from 'api/constants';
+import { PROPOSAL_SORT } from 'api/constants';
 
 export interface ProposalDetail extends Proposal {
   isRequestingPayout: boolean;

--- a/frontend/client/modules/proposals/reducers.ts
+++ b/frontend/client/modules/proposals/reducers.ts
@@ -62,7 +62,7 @@ export const INITIAL_STATE: ProposalState = {
     sort: PROPOSAL_SORT.NEWEST,
     filters: {
       category: [],
-      stage: [PROPOSAL_STAGE.FUNDING_REQUIRED],
+      stage: [],
     },
     items: [],
     hasFetched: false,


### PR DESCRIPTION
### What this does

Sets the default stage filter to "ALL".

### Why?
Showing users proposals that have received funding will help them to see that the platform is active, and hopefully excite them to participate more. 

