### PR TITLE
Fix contribution email

### DIFF
--- a/backend/grant/email/send.py
+++ b/backend/grant/email/send.py
@@ -85,6 +85,8 @@ def proposal_rejected(email_args):
 
 
 def proposal_contribution(email_args):
+    if email_args['contribution'].private:
+        email_args['contributor'] = None
     return {
         'subject': 'You just got a contribution!',
         'title': 'You just got a contribution',


### PR DESCRIPTION
### What this does
- set the contributor to `None` if the contribution is private for the `proposal_contribution` email

### Testing
1. create a proposal & publish it
1. "contribute without attribution" from an authenticated account
1. send the contribution transaction naturally through zcash
1. the email subject and content should not display the contributor details