### PR TITLE
update ZF Grants contact page

### DIFF
--- a/frontend/client/static/markdown/CONTACT.md
+++ b/frontend/client/static/markdown/CONTACT.md
@@ -1,5 +1,9 @@
 # Contact Us
 
-* You may reach out to the Zcash Foundation by emailing us at contact@zfnd.org
-* You can find us on twitter at https://twitter.com/zcashfoundation
-* You can contribute or report issues at https://github.com/ZcashFoundation/zcash-grant-system/issues
+Reach out to [contact@zfnd.org](mailto:contact@zfnd.org) for user support and general inquiries.
+
+The Zcash Foundation can provide feedback on grant ideas, but we encourage you to start with conversations on the [Zcash Community Forum](https://forum.zcashcommunity.com/c/community-collaboration) or the [Zcash Community Chat](https://chat.zcashcommunity.com/channel/the-zcash-foundation).
+
+**Security or privacy issues should be sent to contact@zfnd.org _and_ contact@grant.io to alert the development team immediately.** If you discover a software bug or vulnerability on ZF Grants, please follow the [Responsible Disclosure Policy](https://github.com/ZcashFoundation/zcash-grant-system/blob/develop/DISCLOSURE.md).
+
+Noncritical bugs or feature suggestions can be [submitted as issues in the GitHub repo](https://github.com/ZcashFoundation/zcash-grant-system/issues).


### PR DESCRIPTION
As discussed with @dternyak. Minor changes to the language on the ZF Grants contact page, intended to highlight the different communication channels for different sorts of inquiries.